### PR TITLE
Use public URLs for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "undvc_common"]
 	path = undvc_common
-	url = git://github.com:travisdesell/undvc_common.git
+	url = git://github.com/travisdesell/undvc_common.git
 [submodule "php/bootstrap"]
 	path = php/bootstrap
 	url = git://github.com/twitter/bootstrap.git


### PR DESCRIPTION
If user's don't have ssh keys set up on their github account they won't be able to perform a submodule update when downloading the milkyway@home client
